### PR TITLE
Updated configs

### DIFF
--- a/isp/alice.it.xml
+++ b/isp/alice.it.xml
@@ -39,19 +39,6 @@
       <username>%EMAILADDRESS%</username>
       <authentication>password-cleartext</authentication>
     </outgoingServer>
-    <outgoingServer type="smtp">
-      <hostname>in.alice.it</hostname>
-      <port>587</port>
-      <socketType>STARTTLS</socketType>
-      <username>%EMAILADDRESS%</username>
-      <authentication>password-cleartext</authentication>
-    </outgoingServer>
-    <outgoingServer type="smtp">
-      <hostname>in.alice.it</hostname>
-      <port>25</port>
-      <socketType>STARTTLS</socketType>
-      <username>%EMAILADDRESS%</username>
-      <authentication>password-cleartext</authentication>
-    </outgoingServer>
+    <documentation url="https://www.tim.it/assistenza/assistenza-tecnica/mail/configurazione/protocolli-posta"/>
   </emailProvider>
 </clientConfig>

--- a/isp/aruba.it.xml
+++ b/isp/aruba.it.xml
@@ -5,6 +5,13 @@
     <displayName>Aruba</displayName>
     <displayShortName>Aruba</displayShortName>
     <incomingServer type="imap">
+      <hostname>pop3s.pec.aruba.it</hostname>
+      <port>993</port>
+      <socketType>SSL</socketType>
+      <username>%EMAILADDRESS%</username>
+      <authentication>password-cleartext</authentication>
+    </incomingServer>
+    <incomingServer type="imap">
       <hostname>imaps.pec.aruba.it</hostname>
       <port>143</port>
       <socketType>STARTTLS</socketType>
@@ -17,6 +24,7 @@
       <socketType>SSL</socketType>
       <username>%EMAILADDRESS%</username>
       <authentication>password-cleartext</authentication>
+      <authentication>OAuth2</authentication>
     </incomingServer>
     <incomingServer type="pop3">
       <hostname>pop3s.pec.aruba.it</hostname>
@@ -32,12 +40,6 @@
       <username>%EMAILADDRESS%</username>
       <authentication>password-cleartext</authentication>
     </outgoingServer>
-    <outgoingServer type="smtp">
-      <hostname>smtps.pec.aruba.it</hostname>
-      <port>25</port>
-      <socketType>STARTTLS</socketType>
-      <username>%EMAILADDRESS%</username>
-      <authentication>password-cleartext</authentication>
-    </outgoingServer>
+    <documentation url="https://guide.pec.it/posta-pec/configurare-casella-pec/configurare-casella-pec-programma-posta.aspx"/>
   </emailProvider>
 </clientConfig>

--- a/isp/intekom.co.za.xml
+++ b/isp/intekom.co.za.xml
@@ -1,9 +1,23 @@
 <?xml version="1.0"?>
 <clientConfig version="1.2">
-  <emailProvider id="intekom.co.za ">
+  <emailProvider id="intekom.co.za">
     <domain>intekom.co.za</domain>
     <displayName>Telkom</displayName>
     <displayShortName>Telkom</displayShortName>
+    <incomingServer type="imap">
+      <hostname>mail.intekom.co.za</hostname>
+      <port>993</port>
+      <socketType>SSL</socketType>
+      <username>%EMAILLOCALPART%</username>
+      <authentication>password-cleartext</authentication>
+    </incomingServer>
+    <incomingServer type="imap">
+      <hostname>mail.intekom.co.za</hostname>
+      <port>143</port>
+      <socketType>STARTTLS</socketType>
+      <username>%EMAILLOCALPART%</username>
+      <authentication>password-cleartext</authentication>
+    </incomingServer>
     <incomingServer type="pop3">
       <hostname>pop3.intekom.co.za</hostname>
       <port>110</port>
@@ -25,5 +39,9 @@
       <username>%EMAILLOCALPART%</username>
       <authentication>password-cleartext</authentication>
     </outgoingServer>
+    <documentation url="https://images.telkom.co.za/backend-files/2024-05/Setup%20guide%20for%20outlook.pdf?VersionId=hKWk30ErsdM1TWZBQei_TuGy.SWPUtNH"/>
+    <documentation url="http://www.telkomsa.net/support/support_technical_email_faq.html"/>
+    <documentation url="http://www.telkomsa.net/support/sub/email/email_internet_mail.html"/>
+    <documentation url="https://images.telkom.co.za/backend-files/2024-05/Thunderbird%20Guide_0.pdf?VersionId=hBVF8hFpXpr8E7eUunXh3EudXEHibwJP"/>
   </emailProvider>
 </clientConfig>

--- a/isp/intekom.com.xml
+++ b/isp/intekom.com.xml
@@ -4,6 +4,20 @@
     <domain>intekom.com</domain>
     <displayName>Telkom</displayName>
     <displayShortName>Telkom</displayShortName>
+    <incomingServer type="imap">
+      <hostname>mail.intekom.com</hostname>
+      <port>993</port>
+      <socketType>SSL</socketType>
+      <username>%EMAILLOCALPART%</username>
+      <authentication>password-cleartext</authentication>
+    </incomingServer>
+    <incomingServer type="imap">
+      <hostname>mail.intekom.com</hostname>
+      <port>143</port>
+      <socketType>STARTTLS</socketType>
+      <username>%EMAILLOCALPART%</username>
+      <authentication>password-cleartext</authentication>
+    </incomingServer>
     <incomingServer type="pop3">
       <hostname>pop3.intekom.com</hostname>
       <port>110</port>
@@ -25,5 +39,9 @@
       <username>%EMAILLOCALPART%</username>
       <authentication>password-cleartext</authentication>
     </outgoingServer>
+    <documentation url="https://images.telkom.co.za/backend-files/2024-05/Setup%20guide%20for%20outlook.pdf?VersionId=hKWk30ErsdM1TWZBQei_TuGy.SWPUtNH"/>
+    <documentation url="http://www.telkomsa.net/support/support_technical_email_faq.html"/>
+    <documentation url="http://www.telkomsa.net/support/sub/email/email_internet_mail.html"/>
+    <documentation url="https://images.telkom.co.za/backend-files/2024-05/Thunderbird%20Guide_0.pdf?VersionId=hBVF8hFpXpr8E7eUunXh3EudXEHibwJP"/>
   </emailProvider>
 </clientConfig>

--- a/isp/interia.pl.xml
+++ b/isp/interia.pl.xml
@@ -36,8 +36,6 @@
       <username>%EMAILADDRESS%</username>
       <authentication>password-cleartext</authentication>
     </outgoingServer>
-    <documentation url="https://pomoc.poczta.interia.pl/news-parametry-do-konfiguracji-programow-pocztowych"/>
-    <documentation url="nId"/>
-    <documentation url="2136275"/>
+    <documentation url="https://pomoc.poczta.interia.pl/news-konfiguracja-konta-imap,nId,2136407"/>
   </emailProvider>
 </clientConfig>

--- a/isp/mimecast.com.xml
+++ b/isp/mimecast.com.xml
@@ -4,17 +4,24 @@
     <domain>nestgroup.net</domain>
     <displayName>Mimecast</displayName>
     <displayShortName>Mimecast</displayShortName>
-    <incomingServer type="pop3">
-      <hostname>eu-pop.mimecast.com</hostname>
-      <port>995</port>
+    <incomingServer type="imap">
+      <hostname>mail.mimecast.com</hostname>
+      <port>993</port>
       <socketType>SSL</socketType>
+      <username>%EMAILADDRESS%</username>
+      <authentication>password-cleartext</authentication>
+    </incomingServer>
+    <incomingServer type="imap">
+      <hostname>mail.mimecast.com</hostname>
+      <port>143</port>
+      <socketType>STARTTLS</socketType>
       <username>%EMAILADDRESS%</username>
       <authentication>password-cleartext</authentication>
     </incomingServer>
     <incomingServer type="pop3">
       <hostname>eu-pop.mimecast.com</hostname>
-      <port>110</port>
-      <socketType>STARTTLS</socketType>
+      <port>995</port>
+      <socketType>SSL</socketType>
       <username>%EMAILADDRESS%</username>
       <authentication>password-cleartext</authentication>
     </incomingServer>
@@ -25,19 +32,7 @@
       <username>%EMAILADDRESS%</username>
       <authentication>password-cleartext</authentication>
     </outgoingServer>
-    <outgoingServer type="smtp">
-      <hostname>eu-smtp-outbound-1.mimecast.com</hostname>
-      <port>587</port>
-      <socketType>STARTTLS</socketType>
-      <username>%EMAILADDRESS%</username>
-      <authentication>password-cleartext</authentication>
-    </outgoingServer>
-    <outgoingServer type="smtp">
-      <hostname>eu-smtp-outbound-1.mimecast.com</hostname>
-      <port>25</port>
-      <socketType>STARTTLS</socketType>
-      <username>%EMAILADDRESS%</username>
-      <authentication>password-cleartext</authentication>
-    </outgoingServer>
+    <documentation url="https://community.mimecast.com/s/article/end-user-applications-mimecast-for-outlook-configure-pop3"/>
+    <!--There are different configs for different regions-->
   </emailProvider>
 </clientConfig>

--- a/isp/ptd.net.xml
+++ b/isp/ptd.net.xml
@@ -11,9 +11,16 @@
       <username>%EMAILADDRESS%</username>
       <authentication>password-cleartext</authentication>
     </incomingServer>
-    <incomingServer type="imap">
-      <hostname>promail.ptd.net</hostname>
-      <port>143</port>
+    <incomingServer type="pop3">
+      <hostname>mail.ptd.net</hostname>
+      <port>995</port>
+      <socketType>SSL</socketType>
+      <username>%EMAILADDRESS%</username>
+      <authentication>password-cleartext</authentication>
+    </incomingServer>
+    <incomingServer type="pop3">
+      <hostname>mail.ptd.net</hostname>
+      <port>110</port>
       <socketType>STARTTLS</socketType>
       <username>%EMAILADDRESS%</username>
       <authentication>password-cleartext</authentication>
@@ -25,19 +32,6 @@
       <username>%EMAILADDRESS%</username>
       <authentication>password-cleartext</authentication>
     </outgoingServer>
-    <outgoingServer type="smtp">
-      <hostname>promail.ptd.net</hostname>
-      <port>587</port>
-      <socketType>STARTTLS</socketType>
-      <username>%EMAILADDRESS%</username>
-      <authentication>password-cleartext</authentication>
-    </outgoingServer>
-    <outgoingServer type="smtp">
-      <hostname>promail.ptd.net</hostname>
-      <port>25</port>
-      <socketType>STARTTLS</socketType>
-      <username>%EMAILADDRESS%</username>
-      <authentication>password-cleartext</authentication>
-    </outgoingServer>
+    <documentation url="https://www.ptd.net/support/email-communication/email-server-settings"/>
   </emailProvider>
 </clientConfig>

--- a/isp/tin.it.xml
+++ b/isp/tin.it.xml
@@ -39,12 +39,6 @@
       <username>%EMAILADDRESS%</username>
       <authentication>password-cleartext</authentication>
     </outgoingServer>
-    <outgoingServer type="smtp">
-      <hostname>smtps.tin.it</hostname>
-      <port>25</port>
-      <socketType>STARTTLS</socketType>
-      <username>%EMAILADDRESS%</username>
-      <authentication>password-cleartext</authentication>
-    </outgoingServer>
+    <documentation url="https://www.tim.it/assistenza/assistenza-tecnica/mail/configurazione/protocolli-posta"/>
   </emailProvider>
 </clientConfig>

--- a/isp/tiscali.cz.xml
+++ b/isp/tiscali.cz.xml
@@ -4,6 +4,20 @@
     <domain>tiscali.cz</domain>
     <displayName>tiscali.cz</displayName>
     <displayShortName>tiscali.cz</displayShortName>
+    <incomingServer type="imap">
+      <hostname>mail.tiscali.cz</hostname>
+      <port>993</port>
+      <socketType>SSL</socketType>
+      <username>%EMAILADDRESS%</username>
+      <authentication>password-cleartext</authentication>
+    </incomingServer>
+    <incomingServer type="imap">
+      <hostname>mail.tiscali.cz</hostname>
+      <port>143</port>
+      <socketType>STARTTLS</socketType>
+      <username>%EMAILADDRESS%</username>
+      <authentication>password-cleartext</authentication>
+    </incomingServer>
     <incomingServer type="pop3">
       <hostname>pop3.tiscali.cz</hostname>
       <port>995</port>
@@ -25,12 +39,6 @@
       <username>%EMAILADDRESS%</username>
       <authentication>password-cleartext</authentication>
     </outgoingServer>
-    <outgoingServer type="smtp">
-      <hostname>smtp.tiscali.cz</hostname>
-      <port>25</port>
-      <socketType>STARTTLS</socketType>
-      <username>%EMAILADDRESS%</username>
-      <authentication>password-cleartext</authentication>
-    </outgoingServer>
+    <documentation url="http://home.tiscali.cz/dedekj/registrace_tiscali.html"/>
   </emailProvider>
 </clientConfig>

--- a/isp/versatel.nl.xml
+++ b/isp/versatel.nl.xml
@@ -5,6 +5,20 @@
     <domain>zonnet.nl</domain>
     <displayName>Zonnet</displayName>
     <displayShortName>Zonnet</displayShortName>
+    <incomingServer type="imap">
+      <hostname>mail.versatel.nl</hostname>
+      <port>993</port>
+      <socketType>SSL</socketType>
+      <username>%EMAILLOCALPART%</username>
+      <authentication>password-cleartext</authentication>
+    </incomingServer>
+    <incomingServer type="imap">
+      <hostname>mail.versatel.nl</hostname>
+      <port>143</port>
+      <socketType>STARTTLS</socketType>
+      <username>%EMAILLOCALPART%</username>
+      <authentication>password-cleartext</authentication>
+    </incomingServer>
     <incomingServer type="pop3">
       <hostname>pop3.versatel.nl</hostname>
       <port>995</port>
@@ -33,12 +47,7 @@
       <username>%EMAILLOCALPART%</username>
       <authentication>password-cleartext</authentication>
     </outgoingServer>
-    <outgoingServer type="smtp">
-      <hostname>smtp.versatel.nl</hostname>
-      <port>25</port>
-      <socketType>STARTTLS</socketType>
-      <username>%EMAILLOCALPART%</username>
-      <authentication>password-cleartext</authentication>
-    </outgoingServer>
+    <documentation url="https://www.zonnet.nl/faq/Hoe%20voeg%20ik%20mijn%20e-mailaccount%20toe%20aan%20een%20e-mailprogramma"/>
+    <documentation url="https://www.zonnet.nl/support"/>
   </emailProvider>
 </clientConfig>


### PR DESCRIPTION
### Changes

- These configs didn't get tested properly on the last run of the script because the script had an error where `<username/>` was missing or empty
- `interia.pl` is a different problem, the `docsURL` had commas which the generation script split into several urls
- Some configs had included some servers that didn't work, they are removed in this update
- Trailing spaces were not removed by the previous run so they are removed in this update `intekom.co.za`
- Docs URLs are added now since the script edits instead of overwriting

### Methods

- I edited the script so it would output the XML even if there was a missing `<username/>` then I added it back in manually
- Manually fixed the `docsURL`
- Trailing spaces are removed from the provider domain in this run
- If no configs are not working for a protocol it tests for it in the order `[protocol].[domain]`, `[in/out].[domain]`, `mail.[domain]`
